### PR TITLE
Adding a way go the get elapsed millis according to the pausable clock

### DIFF
--- a/tokio/src/runtime/handle.rs
+++ b/tokio/src/runtime/handle.rs
@@ -289,6 +289,12 @@ cfg_time! {
             self.clock.now()
         }
 
+        /// Get the elapsed millis according to the pausable clock. This
+        /// function will panic if the runtime is not pausable
+        pub fn elapsed_millis(&self) -> u64 {
+            self.clock.elapsed_millis()
+        }
+
         /// Pause the runtime
         pub fn pause(&self) -> bool {
             self.clock.pause()

--- a/tokio/src/time/clock.rs
+++ b/tokio/src/time/clock.rs
@@ -52,6 +52,15 @@ cfg_not_test_util! {
             }
         }
 
+        pub(crate) fn elapsed_millis(&self) -> u64 {
+            if self.pausable {
+                self.pausing_clock.now().elapsed_millis
+            }
+            else {
+                panic!("elapsed time is not supported for non-pausable clocks")
+            }
+        }
+
         pub(crate) fn is_paused(&self) -> bool {
             if self.pausable {
                 self.pausing_clock.is_paused()
@@ -261,6 +270,10 @@ cfg_test_util! {
             }
 
             Instant::from_std(ret)
+        }
+
+        pub(crate) fn elapsed_millis(&self) -> u64 {
+            unreachable!("Not implemented for tests");
         }
 
         pub(crate) fn wait_for_resume(&self) {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
